### PR TITLE
fix: Prefix selector window should now correctly display hidden folders (dot folders)

### DIFF
--- a/frontend/src/pages/settings/settings.tsx
+++ b/frontend/src/pages/settings/settings.tsx
@@ -239,6 +239,7 @@ const Settings: FC = () => {
       const selectedPath = await Dialogs.OpenFile({
         CanChooseDirectories: true,
         CanChooseFiles: false,
+        ShowHiddenFiles: true,
         Title: 'Select A Prefix Folder'
       });
 


### PR DESCRIPTION
During selection of a Prefix path, user is unable to select hidden folders. This should resolve that.