### PR TITLE
feat: add experimental SteamGridDB artwork support

### DIFF
--- a/backend/api/router.go
+++ b/backend/api/router.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"sentinel/backend"
 	"sentinel/backend/config"
+	"sentinel/backend/decky"
 	"sentinel/backend/notifier"
 	"sentinel/backend/steam"
 	"sentinel/backend/watcher"
@@ -114,6 +115,7 @@ func (r *Router) Handler() http.Handler {
 		api.Put("/config/steam-data-source", Wrap(r.handleSetSteamDataSource))
 		api.Put("/config/logging", Wrap(r.handleSetLogging))
 		api.Put("/config/achievement-progress-update-mode", Wrap(r.handleSetAchievementProgressUpdateMode))
+		api.Put("/config/decky/use-steam-grid", Wrap(r.handleSetDeckyUseSteamGrid))
 		api.Post("/config/notification-sound", Wrap(r.handleSetSound))
 		api.Patch("/config/emulator-notification/{index}", Wrap(r.handleToggleEmulatorNotification))
 		api.Post("/config/prefix", Wrap(r.handleAddPrefix))
@@ -137,6 +139,7 @@ func (r *Router) Handler() http.Handler {
 
 	// Serve media files under /api to keep asset paths clean and avoid
 	// confusion with the backend API routes
+	router.Get("/api/media/steamgrid/{shortcutAppId}/portrait", http.HandlerFunc(r.handleServeSteamGridPortrait))
 	router.Get("/api/media/*", http.HandlerFunc(r.handleServeMedia))
 
 	return router
@@ -251,6 +254,22 @@ func (r *Router) handleSetAchievementProgressUpdateMode(w http.ResponseWriter, r
 
 	if err := r.Config.SetAchievementProgressUpdateMode(body.Mode); err != nil {
 		return AppError{Status: http.StatusBadRequest, Message: err.Error()}
+	}
+
+	return JSON(w, http.StatusOK, map[string]string{"status": "success"})
+}
+
+func (r *Router) handleSetDeckyUseSteamGrid(w http.ResponseWriter, req *http.Request) error {
+	var body struct {
+		UseSteamGrid bool `json:"useSteamGrid"`
+	}
+
+	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+		return AppError{Status: http.StatusBadRequest, Message: "Invalid request body"}
+	}
+
+	if err := r.Config.SetDeckyUseSteamGrid(body.UseSteamGrid); err != nil {
+		return AppError{Status: http.StatusInternalServerError, Message: err.Error()}
 	}
 
 	return JSON(w, http.StatusOK, map[string]string{"status": "success"})
@@ -405,6 +424,22 @@ func (r *Router) handleNotifications(w http.ResponseWriter, req *http.Request) e
 	}
 
 	return nil
+}
+
+func (r *Router) handleServeSteamGridPortrait(w http.ResponseWriter, req *http.Request) {
+	shortcutAppID := chi.URLParam(req, "shortcutAppId")
+	if _, err := strconv.ParseUint(shortcutAppID, 10, 32); err != nil {
+		http.Error(w, "Bad Request", http.StatusBadRequest)
+		return
+	}
+
+	portraitPath, err := decky.FindSteamGridPortrait(shortcutAppID)
+	if err != nil {
+		http.Error(w, "Not Found", http.StatusNotFound)
+		return
+	}
+
+	http.ServeFile(w, req, portraitPath)
 }
 
 // handleServeMedia serves local media files (game images, achievement icons, sounds)

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -82,6 +82,10 @@ type AppInfo struct {
 	GitHub      string `json:"github"`
 }
 
+type DeckyConfig struct {
+	UseSteamGrid bool `json:"UseSteamGrid"`
+}
+
 //wails:internal
 type File struct {
 	autostart                     Autostarter
@@ -95,6 +99,7 @@ type File struct {
 	AchievementProgressUpdateMode AchievementProgressUpdateMode `json:"achievementProgressUpdateMode"`
 	LogLevel                      string                        `json:"logLevel"`
 	StartOnLogin                  bool                          `json:"startOnLogin"`
+	Decky                         DeckyConfig                   `json:"decky"`
 }
 
 var defaultEmulatorSources = []EmulatorSource{
@@ -205,6 +210,9 @@ func (c *File) Start(ctx context.Context) error {
 			},
 			LogLevel:     "info",
 			StartOnLogin: true,
+			Decky: DeckyConfig{
+				UseSteamGrid: false,
+			},
 		}
 		config, marshalErr := json.MarshalIndent(defaultConfig, "", "  ")
 		if marshalErr != nil {
@@ -474,6 +482,11 @@ func (c *File) SetAchievementProgressUpdateMode(mode AchievementProgressUpdateMo
 	}
 
 	c.AchievementProgressUpdateMode = mode
+	return c.SaveConfig()
+}
+
+func (c *File) SetDeckyUseSteamGrid(useSteamGrid bool) error {
+	c.Decky.UseSteamGrid = useSteamGrid
 	return c.SaveConfig()
 }
 

--- a/backend/config/config_test.go
+++ b/backend/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -163,6 +164,62 @@ func TestSaveConfig_DefaultsAchievementProgressUpdateMode(t *testing.T) {
 	require.NoError(t, json.Unmarshal(data, &raw))
 
 	assert.Equal(t, string(AchievementProgressUpdateModeDefault), raw["achievementProgressUpdateMode"])
+}
+
+func TestStart_DefaultConfigDisablesDeckySteamGrid(t *testing.T) {
+	_, tempDir := setupTestConfig(t)
+
+	originalConfigDir := backend.ConfigDir
+	originalDataDir := backend.DataDir
+	originalGameCacheDir := backend.GameCacheDir
+	backend.ConfigDir = filepath.Dir(backend.ConfigPath)
+	backend.DataDir = filepath.Join(tempDir, "data")
+	backend.GameCacheDir = filepath.Join(backend.DataDir, "games")
+	t.Cleanup(func() {
+		backend.ConfigDir = originalConfigDir
+		backend.DataDir = originalDataDir
+		backend.GameCacheDir = originalGameCacheDir
+	})
+
+	cfg := &File{}
+	require.NoError(t, cfg.Start(context.Background()))
+
+	var raw map[string]any
+	data, err := os.ReadFile(backend.ConfigPath)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(data, &raw))
+
+	decky, ok := raw["decky"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, false, decky["UseSteamGrid"])
+}
+
+func TestLoadConfig_MissingDeckySectionDefaultsUseSteamGridFalse(t *testing.T) {
+	_, _ = setupTestConfig(t)
+
+	require.NoError(t, os.WriteFile(backend.ConfigPath, []byte(`{"steamDataSource":"external"}`), 0644))
+
+	cfg := &File{}
+	result, err := cfg.LoadConfig()
+	require.NoError(t, err)
+
+	assert.False(t, result.Decky.UseSteamGrid)
+}
+
+func TestSetDeckyUseSteamGrid(t *testing.T) {
+	_, _ = setupTestConfig(t)
+
+	cfg := &File{}
+	require.NoError(t, cfg.SetDeckyUseSteamGrid(true))
+	assert.True(t, cfg.Decky.UseSteamGrid)
+
+	loaded := &File{}
+	_, err := loaded.LoadConfig()
+	require.NoError(t, err)
+	assert.True(t, loaded.Decky.UseSteamGrid)
+
+	require.NoError(t, loaded.SetDeckyUseSteamGrid(false))
+	assert.False(t, loaded.Decky.UseSteamGrid)
 }
 
 func TestSetSteamAPIKey(t *testing.T) {

--- a/backend/decky/decky.go
+++ b/backend/decky/decky.go
@@ -1,6 +1,7 @@
 package decky
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -49,4 +50,36 @@ func IsGamescopeSession() bool {
 
 func IsActiveDeckSession() bool {
 	return IsSteamInBPM() || IsGamescopeSession()
+}
+
+func SteamInstallPath() string {
+	home := os.Getenv("DECKY_USER_HOME")
+	if home == "" {
+		home, _ = os.UserHomeDir()
+	}
+	return filepath.Join(home, ".local", "share", "Steam")
+}
+
+func FindSteamGridPortrait(shortcutAppID string) (string, error) {
+	filename := shortcutAppID + "p.png"
+	userdataPath := filepath.Join(SteamInstallPath(), "userdata")
+
+	userDirs, err := os.ReadDir(userdataPath)
+	if err != nil {
+		return "", err
+	}
+
+	for _, userDir := range userDirs {
+		if !userDir.IsDir() {
+			continue
+		}
+
+		candidate := filepath.Join(userdataPath, userDir.Name(), "config", "grid", filename)
+		info, err := os.Stat(candidate)
+		if err == nil && !info.IsDir() {
+			return candidate, nil
+		}
+	}
+
+	return "", errors.New("steamgrid portrait not found")
 }

--- a/decky-plugin/src/pages/library.tsx
+++ b/decky-plugin/src/pages/library.tsx
@@ -16,6 +16,9 @@ import { BASE_URL, Fetcher } from '@/shared/utils/fetcher';
 import { computeProgress } from '@/shared/utils/utils';
 import type { GameBasics } from '@/shared/types/GameBasics';
 import { styles } from '@/shared/styles';
+import { getAllMappings, setMapping, type GameMapping } from '@/shared/utils/game-mappings';
+import { matchGameByName } from '@/shared/utils/game-matcher';
+import { nonSteamGames, type NonSteamGame } from '@/shared/utils/non-steam-game-tracker';
 
 //language=css
 const libraryStyles = `
@@ -77,10 +80,83 @@ interface LibrarySyncStatus {
   Total: number;
 }
 
+interface AppConfig {
+  decky?: {
+    UseSteamGrid: boolean;
+  };
+}
+
+interface DeckyGameBasics extends GameBasics {
+  FallbackPortraitImage?: string;
+}
+
 const emptySyncStatus: LibrarySyncStatus = { State: 'idle', Current: 0, Total: 0 };
 
+function populateMissingMappings(shortcuts: NonSteamGame[], games: GameBasics[]): Record<number, GameMapping> {
+  const mappings = getAllMappings();
+
+  for (const shortcut of shortcuts) {
+    if (mappings[shortcut.appId]) {
+      continue;
+    }
+
+    const match = matchGameByName(shortcut.name, games);
+    if (!match) {
+      continue;
+    }
+
+    setMapping(shortcut.appId, match.AppID, match.Name, shortcut.name);
+    mappings[shortcut.appId] = {
+      sentinelAppId: match.AppID,
+      sentinelName: match.Name,
+      shortcutName: shortcut.name,
+      createdAt: Date.now()
+    };
+  }
+
+  return mappings;
+}
+
+function findShortcutAppIdForGame(
+  game: GameBasics,
+  mappings: Record<number, GameMapping>,
+  shortcutIds: Set<number>
+): number | null {
+  for (const [shortcutAppId, mapping] of Object.entries(mappings)) {
+    const parsedShortcutAppId = Number(shortcutAppId);
+    if (mapping.sentinelAppId === game.AppID && shortcutIds.has(parsedShortcutAppId)) {
+      return parsedShortcutAppId;
+    }
+  }
+
+  return null;
+}
+
+function decorateGames(config: AppConfig, games: GameBasics[]): DeckyGameBasics[] {
+  if (!config.decky?.UseSteamGrid) {
+    return games;
+  }
+
+  const shortcuts = nonSteamGames();
+  const shortcutIds = new Set(shortcuts.map((game) => game.appId));
+  const mappings = populateMissingMappings(shortcuts, games);
+
+  return games.map((game) => {
+    const shortcutAppId = findShortcutAppIdForGame(game, mappings, shortcutIds);
+    if (!shortcutAppId) {
+      return game;
+    }
+
+    return {
+      ...game,
+      FallbackPortraitImage: game.PortraitImage,
+      PortraitImage: `/api/media/steamgrid/${shortcutAppId}/portrait`
+    };
+  });
+}
+
 const LibraryPage: FC = () => {
-  const [games, setGames] = useState<GameBasics[]>([]);
+  const [games, setGames] = useState<DeckyGameBasics[]>([]);
   const [loading, setLoading] = useState(true);
   const [syncStatus, setSyncStatus] = useState<LibrarySyncStatus>(emptySyncStatus);
   const [refreshingGameIds, setRefreshingGameIds] = useState<string[]>([]);
@@ -92,9 +168,13 @@ const LibraryPage: FC = () => {
     }
 
     try {
-      const data = await fetcher.get<GameBasics[]>(`${BASE_URL}/games`);
-      setGames(data);
-      return data;
+      const [config, data] = await Promise.all([
+        fetcher.get<AppConfig>(`${BASE_URL}/config`),
+        fetcher.get<GameBasics[]>(`${BASE_URL}/games`)
+      ]);
+      const decoratedGames = decorateGames(config, data);
+      setGames(decoratedGames);
+      return decoratedGames;
     } catch {
       if (clearOnError) {
         setGames([]);
@@ -163,14 +243,18 @@ const LibraryPage: FC = () => {
     setRefreshingGameIds((current) => [...current, appId]);
 
     try {
-      const refreshedGame = await fetcher.post<GameBasics>(`${BASE_URL}/games/${appId}/refresh`, {});
+      const [config, refreshedGame] = await Promise.all([
+        fetcher.get<AppConfig>(`${BASE_URL}/config`),
+        fetcher.post<GameBasics>(`${BASE_URL}/games/${appId}/refresh`, {})
+      ]);
+      const decoratedGame = decorateGames(config, [refreshedGame])[0];
       setGames((current) =>
         current.map((game) => {
-          if (game.AppID !== refreshedGame.AppID) {
+          if (game.AppID !== decoratedGame.AppID) {
             return game;
           }
 
-          return refreshedGame;
+          return decoratedGame;
         })
       );
       toaster.toast({ title: 'Success', body: `${refreshedGame.Name || 'Game'} refreshed` });
@@ -236,6 +320,7 @@ const LibraryPage: FC = () => {
                 <LibraryImage
                   key={game.AppID}
                   src={game.PortraitImage}
+                  fallbackSrc={game.FallbackPortraitImage}
                   alt={game.Name}
                   name={game.Name}
                   progress={progress}

--- a/decky-plugin/src/pages/settings.tsx
+++ b/decky-plugin/src/pages/settings.tsx
@@ -32,6 +32,10 @@ interface Emulator {
   shouldNotify: boolean;
 }
 
+interface DeckyConfig {
+  UseSteamGrid: boolean;
+}
+
 interface AppConfig {
   prefixes: Prefix[];
   emulators: Emulator[];
@@ -40,6 +44,7 @@ interface AppConfig {
   notificationSound: string;
   logLevel: string;
   achievementProgressUpdateMode: string;
+  decky?: DeckyConfig;
 }
 
 interface SoundOption {
@@ -244,6 +249,26 @@ const SettingsPage: FC = () => {
     }
   };
 
+  const handleUseSteamGridToggle = async (enabled: boolean) => {
+    if (enabled) {
+      const confirmed = await showConfirmModal({
+        title: 'Experimental SteamGridDB Images',
+        description:
+          'SteamGridDB must already be installed. Sentinel does not download images and assumes you have already updated your artwork using the default SteamGridDB methods.',
+        okText: 'Enable',
+        cancelText: 'Cancel'
+      });
+      if (!confirmed) return;
+    }
+
+    try {
+      await fetcher.put(`${BASE_URL}/config/decky/use-steam-grid`, { useSteamGrid: enabled });
+      setConfig((prev) => (prev ? { ...prev, decky: { ...(prev.decky ?? { UseSteamGrid: false }), UseSteamGrid: enabled } } : prev));
+    } catch {
+      toaster.toast({ title: 'Error', body: 'Failed to update SteamGridDB image setting' });
+    }
+  };
+
   const prefixes = config?.prefixes || [];
   const emulators = config?.emulators || [];
 
@@ -303,6 +328,12 @@ const SettingsPage: FC = () => {
                     selectedOption={stmSrc}
                     onChange={(option) => handleSteamDataSourceChange(option.data)}
                   />
+                </Field>
+              </DialogControlsSection>
+              <DialogControlsSection>
+                <DialogControlsSectionHeader>Library Images</DialogControlsSectionHeader>
+                <Field label='Experimental SteamGridDB Images'>
+                  <Toggle value={config?.decky?.UseSteamGrid ?? false} onChange={handleUseSteamGridToggle} />
                 </Field>
               </DialogControlsSection>
               <DialogControlsSection>

--- a/decky-plugin/src/shared/components/library-image.tsx
+++ b/decky-plugin/src/shared/components/library-image.tsx
@@ -1,4 +1,4 @@
-import { FC, useRef } from 'react';
+import { FC, useEffect, useRef, useState } from 'react';
 import { Focusable, joinClassNames, libraryAssetImageClasses, ProgressBar } from '@decky/ui';
 import { ASSET_URL } from '@/shared/utils/fetcher';
 
@@ -31,6 +31,7 @@ const libraryImageStyles = `
 
 export interface LibraryImageProps {
   src: string;
+  fallbackSrc?: string;
   alt?: string;
   name?: string;
   onError?: () => void;
@@ -42,13 +43,27 @@ export interface LibraryImageProps {
 
 const LibraryImage: FC<LibraryImageProps> = ({
   src,
+  fallbackSrc,
   alt = '',
+  onError,
   progress,
   onActivate,
   onOpenContextMenu,
   isRefreshing = false
 }) => {
   const focusableRef = useRef<HTMLDivElement | null>(null);
+  const [activeSrc, setActiveSrc] = useState(src);
+
+  useEffect(() => {
+    setActiveSrc(src);
+  }, [src]);
+
+  const handleImageError = () => {
+    onError?.();
+    if (fallbackSrc && activeSrc !== fallbackSrc) {
+      setActiveSrc(fallbackSrc);
+    }
+  };
 
   return (
     <>
@@ -71,8 +86,9 @@ const LibraryImage: FC<LibraryImageProps> = ({
         )}
       >
         <img
-          src={`${ASSET_URL}${src}`}
+          src={`${ASSET_URL}${activeSrc}`}
           alt={alt}
+          onError={handleImageError}
           className={joinClassNames(
             libraryAssetImageClasses.Image,
             libraryAssetImageClasses.Visibility,

--- a/decky-plugin/src/shared/utils/non-steam-game-tracker.ts
+++ b/decky-plugin/src/shared/utils/non-steam-game-tracker.ts
@@ -1,7 +1,7 @@
 import { findModuleExport } from '@decky/ui';
 import { EDisplayStatus, EAppType } from '@decky/ui/dist/globals/steam-client/App';
 
-interface NonSteamGame {
+export interface NonSteamGame {
   appId: number;
   name: string;
   isRunning: boolean;
@@ -175,4 +175,8 @@ export function initTracker(): TrackerCleanup {
 
 export function runningGames(): NonSteamGame[] {
   return Array.from(cache.values()).filter((game) => game.isRunning);
+}
+
+export function nonSteamGames(): NonSteamGame[] {
+  return Array.from(cache.values());
 }


### PR DESCRIPTION
This adds experimental support for SteamGridDB images. 
User needs to do the the following 

1. Have decky-SteamGridDB installed 
2. Change artwork using decky-SteamGridDB
3. Toggle the "Use Experimental SteamGridDB" feature in sentinel-decky
4. SteamGridDB images are now used in Sentinel library, achievement page, and now-playing 