### PR TITLE
fix(decky): apply SteamGrid artwork on achievement page

### DIFF
--- a/decky-plugin/src/pages/achievements.tsx
+++ b/decky-plugin/src/pages/achievements.tsx
@@ -16,6 +16,7 @@ import {
 import { LibraryImage } from '@/shared/components/library-image';
 import { ASSET_URL, BASE_URL, Fetcher } from '@/shared/utils/fetcher';
 import type { GameBasics } from '@/shared/types/GameBasics';
+import { decorateGames, type DeckyGameBasics } from '@/shared/utils/steamgrid';
 import { computeProgress } from '@/shared/utils/utils';
 import { styles } from '@/shared/styles';
 import { FaArrowDown, FaArrowUp, FaClock, FaHistory } from 'react-icons/fa';
@@ -178,7 +179,7 @@ const achievementStyles = `
 const AchievementsPage: FC = () => {
   const appId = window.location.pathname.split('/games/')[1];
 
-  const [game, setGame] = useState<GameBasics | null>(null);
+  const [game, setGame] = useState<DeckyGameBasics | null>(null);
   const [globalPercentages, setGlobalPercentages] = useState<Map<string, number>>(new Map());
   const [isLoading, setIsLoading] = useState(true);
   const [sortBy, setSortBy] = useState<SortOption>(() => {
@@ -199,8 +200,12 @@ const AchievementsPage: FC = () => {
     const loadData = async () => {
       if (!appId) return;
       try {
-        const games = await fetcher.get<GameBasics[]>(`${BASE_URL}/games`);
-        const found = games.find((g) => g.AppID === appId);
+        const [config, games] = await Promise.all([
+          fetcher.get<{ decky?: { UseSteamGrid: boolean } }>(`${BASE_URL}/config`),
+          fetcher.get<GameBasics[]>(`${BASE_URL}/games`)
+        ]);
+        const decorated = decorateGames(config, games);
+        const found = decorated.find((g) => g.AppID === appId);
         setGame(found ?? null);
       } catch {
         setGame(null);
@@ -301,7 +306,7 @@ const AchievementsPage: FC = () => {
       <div className='sentinel-achievement-container'>
         <div className='sentinel-achievement-sidebar'>
           <div className='sentinel-achievement-sidebar-image'>
-            <LibraryImage src={game.PortraitImage} alt={game.Name} />
+            <LibraryImage src={game.PortraitImage} fallbackSrc={game.FallbackPortraitImage} alt={game.Name} />
           </div>
           <ProgressBar nProgress={stats.percentage} focusable={false} />
           <div className='sentinel-achievement-stats'>

--- a/decky-plugin/src/pages/library.tsx
+++ b/decky-plugin/src/pages/library.tsx
@@ -16,9 +16,7 @@ import { BASE_URL, Fetcher } from '@/shared/utils/fetcher';
 import { computeProgress } from '@/shared/utils/utils';
 import type { GameBasics } from '@/shared/types/GameBasics';
 import { styles } from '@/shared/styles';
-import { getAllMappings, setMapping, type GameMapping } from '@/shared/utils/game-mappings';
-import { matchGameByName } from '@/shared/utils/game-matcher';
-import { nonSteamGames, type NonSteamGame } from '@/shared/utils/non-steam-game-tracker';
+import { decorateGames, type AppConfig, type DeckyGameBasics } from '@/shared/utils/steamgrid';
 
 //language=css
 const libraryStyles = `
@@ -80,80 +78,7 @@ interface LibrarySyncStatus {
   Total: number;
 }
 
-interface AppConfig {
-  decky?: {
-    UseSteamGrid: boolean;
-  };
-}
-
-interface DeckyGameBasics extends GameBasics {
-  FallbackPortraitImage?: string;
-}
-
 const emptySyncStatus: LibrarySyncStatus = { State: 'idle', Current: 0, Total: 0 };
-
-function populateMissingMappings(shortcuts: NonSteamGame[], games: GameBasics[]): Record<number, GameMapping> {
-  const mappings = getAllMappings();
-
-  for (const shortcut of shortcuts) {
-    if (mappings[shortcut.appId]) {
-      continue;
-    }
-
-    const match = matchGameByName(shortcut.name, games);
-    if (!match) {
-      continue;
-    }
-
-    setMapping(shortcut.appId, match.AppID, match.Name, shortcut.name);
-    mappings[shortcut.appId] = {
-      sentinelAppId: match.AppID,
-      sentinelName: match.Name,
-      shortcutName: shortcut.name,
-      createdAt: Date.now()
-    };
-  }
-
-  return mappings;
-}
-
-function findShortcutAppIdForGame(
-  game: GameBasics,
-  mappings: Record<number, GameMapping>,
-  shortcutIds: Set<number>
-): number | null {
-  for (const [shortcutAppId, mapping] of Object.entries(mappings)) {
-    const parsedShortcutAppId = Number(shortcutAppId);
-    if (mapping.sentinelAppId === game.AppID && shortcutIds.has(parsedShortcutAppId)) {
-      return parsedShortcutAppId;
-    }
-  }
-
-  return null;
-}
-
-function decorateGames(config: AppConfig, games: GameBasics[]): DeckyGameBasics[] {
-  if (!config.decky?.UseSteamGrid) {
-    return games;
-  }
-
-  const shortcuts = nonSteamGames();
-  const shortcutIds = new Set(shortcuts.map((game) => game.appId));
-  const mappings = populateMissingMappings(shortcuts, games);
-
-  return games.map((game) => {
-    const shortcutAppId = findShortcutAppIdForGame(game, mappings, shortcutIds);
-    if (!shortcutAppId) {
-      return game;
-    }
-
-    return {
-      ...game,
-      FallbackPortraitImage: game.PortraitImage,
-      PortraitImage: `/api/media/steamgrid/${shortcutAppId}/portrait`
-    };
-  });
-}
 
 const LibraryPage: FC = () => {
   const [games, setGames] = useState<DeckyGameBasics[]>([]);

--- a/decky-plugin/src/shared/utils/steamgrid.ts
+++ b/decky-plugin/src/shared/utils/steamgrid.ts
@@ -1,0 +1,80 @@
+import type { GameBasics } from '@/shared/types/GameBasics';
+import { getAllMappings, setMapping, type GameMapping } from '@/shared/utils/game-mappings';
+import { matchGameByName } from '@/shared/utils/game-matcher';
+import { nonSteamGames, type NonSteamGame } from '@/shared/utils/non-steam-game-tracker';
+
+interface AppConfig {
+  decky?: {
+    UseSteamGrid: boolean;
+  };
+}
+
+interface DeckyGameBasics extends GameBasics {
+  FallbackPortraitImage?: string;
+}
+
+function populateMissingMappings(shortcuts: NonSteamGame[], games: GameBasics[]): Record<number, GameMapping> {
+  const mappings = getAllMappings();
+
+  for (const shortcut of shortcuts) {
+    if (mappings[shortcut.appId]) {
+      continue;
+    }
+
+    const match = matchGameByName(shortcut.name, games);
+    if (!match) {
+      continue;
+    }
+
+    setMapping(shortcut.appId, match.AppID, match.Name, shortcut.name);
+    mappings[shortcut.appId] = {
+      sentinelAppId: match.AppID,
+      sentinelName: match.Name,
+      shortcutName: shortcut.name,
+      createdAt: Date.now()
+    };
+  }
+
+  return mappings;
+}
+
+function findShortcutAppIdForGame(
+  game: GameBasics,
+  mappings: Record<number, GameMapping>,
+  shortcutIds: Set<number>
+): number | null {
+  for (const [shortcutAppId, mapping] of Object.entries(mappings)) {
+    const parsedShortcutAppId = Number(shortcutAppId);
+    if (mapping.sentinelAppId === game.AppID && shortcutIds.has(parsedShortcutAppId)) {
+      return parsedShortcutAppId;
+    }
+  }
+
+  return null;
+}
+
+function decorateGames(config: AppConfig, games: GameBasics[]): DeckyGameBasics[] {
+  if (!config.decky?.UseSteamGrid) {
+    return games;
+  }
+
+  const shortcuts = nonSteamGames();
+  const shortcutIds = new Set(shortcuts.map((game) => game.appId));
+  const mappings = populateMissingMappings(shortcuts, games);
+
+  return games.map((game) => {
+    const shortcutAppId = findShortcutAppIdForGame(game, mappings, shortcutIds);
+    if (!shortcutAppId) {
+      return game;
+    }
+
+    return {
+      ...game,
+      FallbackPortraitImage: game.PortraitImage,
+      PortraitImage: `/api/media/steamgrid/${shortcutAppId}/portrait`
+    };
+  });
+}
+
+export type { AppConfig, DeckyGameBasics };
+export { decorateGames };


### PR DESCRIPTION
Extract decorateGames into a shared util and reuse it on the achievement page so the sidebar portrait respects the SteamGrid setting, mirroring the library behavior.